### PR TITLE
Clear serializer cache when Laravel cache is cleared

### DIFF
--- a/src/Framework/Commands/SerializerClearCommand.php
+++ b/src/Framework/Commands/SerializerClearCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace LaravelSerializer\Framework\Commands;
+
+use Illuminate\Console\Command;
+
+class SerializerClearCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $name = 'serializer:clear';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Flush the serializer cache';
+
+    public function handle(): void
+    {
+        $cache = sprintf("%s/serializer", config('serializer.cache'));
+
+        $this->deleteDirectory($cache);
+
+        $this->components->info('Serializer cache cleared successfully.');
+    }
+
+    private function deleteDirectory($directory): bool
+    {
+        if (!file_exists($directory)) {
+            return true;
+        }
+
+        if (!is_dir($directory)) {
+            return unlink($directory);
+        }
+
+        foreach (scandir($directory) as $item) {
+            if ($item == '.' || $item == '..') {
+                continue;
+            }
+
+            if (!$this->deleteDirectory($directory . DIRECTORY_SEPARATOR . $item)) {
+                return false;
+            }
+
+        }
+
+        return rmdir($directory);
+    }
+}

--- a/src/Framework/Providers/RequestSerializationProvider.php
+++ b/src/Framework/Providers/RequestSerializationProvider.php
@@ -12,6 +12,8 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Contracts\CallableDispatcher;
 use Illuminate\Routing\Contracts\ControllerDispatcher;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use JsonException;
 use LaravelSerializer\Decoder\CarbonDecoder;
@@ -96,6 +98,8 @@ class RequestSerializationProvider extends ServiceProvider
         $this->app->bind(JsonSerializer::class, fn() => new JsonSerializer($encoder, $decoder));
         $this->app->singleton(CallableDispatcher::class, SerializerCallableDispatcher::class);
         $this->app->singleton(ControllerDispatcher::class, SerializerControllerDispatcher::class);
+
+        $this->registerEvents();
     }
 
     /**
@@ -133,5 +137,10 @@ class RequestSerializationProvider extends ServiceProvider
         return new HttpResponseException(
             response: new JsonResponse(['message' => $message], Response::HTTP_BAD_REQUEST),
         );
+    }
+
+    private function registerEvents(): void
+    {
+        Event::listen('cache:cleared', fn () => Artisan::call('serializer:clear'));
     }
 }


### PR DESCRIPTION
This will ensure that the serializer's custom cache is cleared whenever Laravel's cache gets cleared (either via the built-in  `optimize:clear` or `cache:clear` commands).