### PR TITLE
Fix unregistered command error

### DIFF
--- a/src/Framework/Providers/RequestSerializationProvider.php
+++ b/src/Framework/Providers/RequestSerializationProvider.php
@@ -20,6 +20,7 @@ use LaravelSerializer\Decoder\CarbonDecoder;
 use LaravelSerializer\Decoder\CarbonImmutableDecoder;
 use LaravelSerializer\Encoder\CarbonEncoder;
 use LaravelSerializer\Encoder\CarbonImmutableEncoder;
+use LaravelSerializer\Framework\Commands\SerializerClearCommand;
 use LaravelSerializer\Framework\Dispatcher\SerializerCallableDispatcher;
 use LaravelSerializer\Framework\Dispatcher\SerializerControllerDispatcher;
 use Psr\Container\ContainerExceptionInterface;
@@ -99,6 +100,7 @@ class RequestSerializationProvider extends ServiceProvider
         $this->app->singleton(CallableDispatcher::class, SerializerCallableDispatcher::class);
         $this->app->singleton(ControllerDispatcher::class, SerializerControllerDispatcher::class);
 
+        $this->registerCommands();
         $this->registerEvents();
     }
 
@@ -158,6 +160,13 @@ class RequestSerializationProvider extends ServiceProvider
         return new HttpResponseException(
             response: new JsonResponse(['message' => $message], Response::HTTP_BAD_REQUEST),
         );
+    }
+
+    private function registerCommands(): void
+    {
+        $this->commands([
+            SerializerClearCommand::class,
+        ]);
     }
 
     private function registerEvents(): void


### PR DESCRIPTION
Although the `serialize:clear` command works, when users run `composer install` they are met with the following error because the command is not registered:

<img width="701" alt="image" src="https://github.com/thiagocordeiro/laravel-serializer/assets/102794323/80ec4cb0-39fc-4030-b082-bdbd52848130">
